### PR TITLE
Moved Source XRef report to the beginning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,11 @@
                     <reportPlugins>
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-jxr-plugin</artifactId>
+                            <version>2.3</version>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-checkstyle-plugin</artifactId>
                             <version>2.11</version>
                             <configuration>
@@ -210,11 +215,6 @@
                             <version>${org.codehaus.mojo.cobertura-maven-plugin}</version>
                             <configuration>
                             </configuration>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-jxr-plugin</artifactId>
-                            <version>2.3</version>
                         </plugin>
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
- moved source xref report to the beginning as cpd and other plugins failed to create the required links
